### PR TITLE
fix: show warning when saving empty note

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,19 @@
 
 A simple Visual Studio Code extension that opens a React-based webview to let users write, save, and clear personal notes right inside VS Code!
 we are gonna add more cool features soon!
----
-
-##  Current Features
-
--  Write and save quick notes
--  Stores notes using browser `localStorage`
--  Loads saved notes automatically
--  Built using **React**, **Webpack**, and **VS Code API**
 
 ---
 
-##  Prerequisites
+## Current Features
+
+- Write and save quick notes
+- Stores notes using browser `localStorage`
+- Loads saved notes automatically
+- Built using **React**, **Webpack**, and **VS Code API**
+
+---
+
+## Prerequisites
 
 Make sure you have the following installed:
 
@@ -23,25 +24,28 @@ Make sure you have the following installed:
 
 ---
 
-##  Setup Instructions
+## Setup Instructions
 
 ### 1. Clone the repository
 
-```bash```
-git clone https://github.com/your-username/vscode-notes-extension.git
-cd vscode-notes-extension
+`bash`
+git clone https://github.com/your-username/VS-code-Extension.git
+cd VS-code-Extension
 
 ### 2. Install dependencies
+
 npm install
 
 ### 3. Build the React Webview
+
 npx webpack
 
 Wondering how to run the extension? here you go:
+
 1. Open the folder in VS Code
 2. Press F5 to launch an Extension Development Host.
 3. In the new VS Code window, open Command Palette (Ctrl+Shift+P or Cmd+Shift+P) and search:
-"Show React Webview"
+   "Show React Webview"
 
 ### Tadaaa! Your note-taking UI will now appear!
 
@@ -49,57 +53,53 @@ Wondering how to run the extension? here you go:
 
 vscode-notes-extension/
 ├── .vscode/
-│   └── launch.json          # VS Code debugger config
+│ └── launch.json # VS Code debugger config
 ├── dist/
-│   └── bundle.js            # Webview output by Webpack
+│ └── bundle.js # Webview output by Webpack
 ├── src/
-│   ├── App.js               # React component for notes
-│   └── index.js             # Entry file for Webpack
-├── extension.js             # Main VS Code extension logic
-├── package.json             # Project metadata & dependencies
-├── webpack.config.js        # Webpack config file
-└── README.md                # This file
-
-
+│ ├── App.js # React component for notes
+│ └── index.js # Entry file for Webpack
+├── extension.js # Main VS Code extension logic
+├── package.json # Project metadata & dependencies
+├── webpack.config.js # Webpack config file
+└── README.md # This file
 
 ## Scripts
+
 In package.json, you can add:
 
 "scripts": {
-  "build": "webpack",
-  "watch": "webpack --watch"}
+"build": "webpack",
+"watch": "webpack --watch"}
 
 then run:
-npm run build    # One-time build
-npm run watch    # Auto-rebuild on changes
+npm run build # One-time build
+npm run watch # Auto-rebuild on changes
 
 ## Contributing
+
 Want to improve this extension? Awesome!
 
 1. Fork the repo.
 
 2. Create a new branch:
-command: git checkout -b feature/your-feature
+   command: git checkout -b feature/your-feature
 
-3. Make your changes and build: 
-command: npx webpack
+3. Make your changes and build:
+   command: npx webpack
 
 4. Commit and push:
-commands: git add .
-git commit -m "Add: your message"
-git push origin feature/your-feature
+   commands: git add .
+   git commit -m "Add: your message"
+   git push origin feature/your-feature
 
 5. Open a Pull Request.
 
 ## Gotchas
+
 1. Missing CLI error? Run:
-npm install -D webpack-cli
+   npm install -D webpack-cli
 
 2. Not seeing your changes? Rebuild with npx webpack and restart the Extension Host window.
 
 ### Made with 💙 by @sakina1303
-
-
-
-
-

--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
       }
     ]
   },
-  "scripts": {
-     "build": "webpack"
-  },
+"scripts": {
+  "build": "webpack",
+  "watch": "webpack --watch"
+}
+,
   "categories": [
     "Other"
   ],

--- a/src/app.js
+++ b/src/app.js
@@ -3,26 +3,35 @@ import React, { useState, useEffect } from "react";
 const App = () => {
   const [note, setNote] = useState("");
   const [savedNote, setSavedNote] = useState("");
+  const [warning, setWarning] = useState("")
 
 
   useEffect(() => {
     const saved = localStorage.getItem("my-vscode-note");
     if (saved) {
       setSavedNote(saved);
-      setNote(saved);
+      setNote("");
     }
   }, []);
 
   const handleSave = () => {
+
+    if (note.trim() === "") {
+      setWarning("Cannot Save empty note!")
+      return
+    }
+
+    setWarning("")
     localStorage.setItem("my-vscode-note", note);
     setSavedNote(note);
-    alert("✅ Note Saved!");
+    setNote("")
   };
 
   const handleClear = () => {
     localStorage.removeItem("my-vscode-note");
     setNote("");
     setSavedNote("");
+    setWarning("")
   };
 
   return (
@@ -42,6 +51,9 @@ const App = () => {
           🧹 Clear
         </button>
       </div>
+
+      {warning && <div style={styles.warning}>{warning}</div>}
+
       {savedNote && (
         <div style={styles.saved}>
           <strong>🗒️ Saved Note:</strong>
@@ -100,6 +112,12 @@ const styles = {
     borderRadius: "6px",
     border: "1px solid #ccc",
   },
+  warning: {
+    color: "#cc3300",
+    margin: "30px 30px",
+    fontWeight: "bold",
+    fontSize: "20px"
+  }
 };
 
 export default App;

--- a/src/app.js
+++ b/src/app.js
@@ -115,3 +115,8 @@ const styles = {
     color: "#cc3300",
     margin: "30px 30px",
     fontWeight: "bold",
+    fontSize: "20px",
+  },
+};
+
+export default App;

--- a/src/app.js
+++ b/src/app.js
@@ -3,8 +3,7 @@ import React, { useState, useEffect } from "react";
 const App = () => {
   const [note, setNote] = useState("");
   const [savedNote, setSavedNote] = useState("");
-  const [warning, setWarning] = useState("")
-
+  const [warning, setWarning] = useState("");
 
   useEffect(() => {
     const saved = localStorage.getItem("my-vscode-note");
@@ -15,23 +14,23 @@ const App = () => {
   }, []);
 
   const handleSave = () => {
-
     if (note.trim() === "") {
-      setWarning("Cannot Save empty note!")
-      return
+      setWarning("Cannot Save empty note!");
+      return;
     }
 
-    setWarning("")
+    setWarning("");
     localStorage.setItem("my-vscode-note", note);
     setSavedNote(note);
-    setNote("")
+    alert("✅ Note Saved!"); 
+    setNote("");
   };
 
   const handleClear = () => {
     localStorage.removeItem("my-vscode-note");
     setNote("");
     setSavedNote("");
-    setWarning("")
+    setWarning("");
   };
 
   return (
@@ -116,8 +115,3 @@ const styles = {
     color: "#cc3300",
     margin: "30px 30px",
     fontWeight: "bold",
-    fontSize: "20px"
-  }
-};
-
-export default App;


### PR DESCRIPTION
Instead of using an alert popup for empty notes, I’ve added a warning message directly in the UI