### PR TITLE
fix(webview): add CSP-compliant nonce for script security

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -25,20 +25,32 @@ function getWebviewContent(panel) {
   );
   const bundleUri = panel.webview.asWebviewUri(bundlePath);
 
+  const nonce = getNonce();
+
   return `
     <!DOCTYPE html>
     <html lang="en">
     <head>
       <meta charset="UTF-8" />
+      <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'nonce-${nonce}'; style-src 'unsafe-inline';">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <title>React Webview</title>
     </head>
     <body>
       <div id="root"></div>
-      <script src="${bundleUri}"></script>
+      <script nonce="${nonce}" src="${bundleUri}"></script>
     </body>
     </html>
   `;
+}
+
+function getNonce() {
+  let text = '';
+  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  for (let i = 0; i < 32; i++) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+  return text;
 }
 
 function deactivate() {}


### PR DESCRIPTION
Fix #20

This update improves the security of the webview by adding a `nonce` to the `<script>` tag, following VS Code's Content Security Policy (CSP) guidelines.

- Dynamically generates a secure nonce.
- Applies it to the script tag loading the React bundle.
- Ensures the extension follows best practices for secure webviews.
