### PR TITLE
Fix: Package.json syntax & update Webpack config for VS Code CSP compliance

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 
   "scripts": {
     "start": "webpack serve --mode development",
-    "build": "webpack"
+    "build": "webpack",
     "watch": "webpack --watch"
   },
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,22 +1,18 @@
 const path = require("path");
 
 module.exports = {
-  mode: "development",
+  mode: "production",
   entry: "./src/index.js",
   output: {
     path: path.resolve(__dirname, "dist"),
     filename: "bundle.js",
+    publicPath: './',
   },
-  resolve: {
-    alias: {
-      react: path.resolve('./node_modules/react'),
-      'react-dom': path.resolve('./node_modules/react-dom'),
-    },
-  },
+  devtool: "source-map",
   module: {
     rules: [
       {
-        test: /\.js$/,
+        test: /\.jsx?$/,
         exclude: /node_modules/,
         use: {
           loader: "babel-loader",


### PR DESCRIPTION
### Changes Made
- Fixed syntax issue in `package.json` by adding the missing comma.
- Updated `webpack.config.js`:
  - `mode: production` for optimized builds
  - `publicPath: './'` for correct asset loading in VS Code webview
  - `devtool: "source-map"` for development debugging without CSP violations
  - Removed `eval()` usage to comply with VS Code CSP

### Why
- Fixed JSON parsing error.
- Prevented CSP-related errors in VS Code webview (`unsafe-eval` issue → blank screen fixed).
- Secure, stable setup for future development.